### PR TITLE
Fix for the latest double weekly level

### DIFF
--- a/src/utils/Streak.cpp
+++ b/src/utils/Streak.cpp
@@ -5,7 +5,8 @@ using namespace geode::prelude;
 int Streak::calculate(const GJTimedLevelType& type) {
     const std::vector<std::array<int, 2>> doubleDailies = {
         { 2983, 2984 },
-        { 3095, 3096 }
+        { 3095, 3096 },
+        { 100431, 100432 },
     };
 
     return calculate(type, doubleDailies);


### PR DESCRIPTION
This pull request fixes #8 without any major changes to your code by simply ignoring weekly demon 431 using `doubleDailies` vector.
It would be nice to make it more robust as i'm pretty sure that this will happen again in the future.